### PR TITLE
Add option to configure native signals handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,6 +159,36 @@
                                 "items": {
                                     "type": "string"
                                 }
+                            },
+                            "signals": {
+                                "description": "Signals configuration.",
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "pass": {
+                                            "type": "boolean",
+                                            "default": false
+                                        },
+                                        "stop": {
+                                            "type": "boolean",
+                                            "default": false
+                                        },
+                                        "notify": {
+                                            "type": "boolean",
+                                            "default": false
+                                        }
+                                    }
+                                },
+                                "default": [
+                                    {
+                                        "name": "SIGSEGV",
+                                        "pass": true
+                                    }
+                                ]
                             }
                         }
                     }
@@ -312,6 +342,36 @@
                                         "items": {
                                             "type": "string"
                                         }
+                                    },
+                                    "signals": {
+                                        "description": "Signals configuration.",
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "pass": {
+                                                    "type": "boolean",
+                                                    "default": false
+                                                },
+                                                "stop": {
+                                                    "type": "boolean",
+                                                    "default": false
+                                                },
+                                                "notify": {
+                                                    "type": "boolean",
+                                                    "default": false
+                                                }
+                                            }
+                                        },
+                                        "default": [
+                                            {
+                                                "name": "SIGSEGV",
+                                                "pass": true
+                                            }
+                                        ]
                                     }
                                 }
                             },
@@ -451,6 +511,36 @@
                                         "items": {
                                             "type": "string"
                                         }
+                                    },
+                                    "signals": {
+                                        "description": "Signals configuration.",
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "pass": {
+                                                    "type": "boolean",
+                                                    "default": false
+                                                },
+                                                "stop": {
+                                                    "type": "boolean",
+                                                    "default": false
+                                                },
+                                                "notify": {
+                                                    "type": "boolean",
+                                                    "default": false
+                                                }
+                                            }
+                                        },
+                                        "default": [
+                                            {
+                                                "name": "SIGSEGV",
+                                                "pass": true
+                                            }
+                                        ]
                                     }
                                 }
                             },


### PR DESCRIPTION
I need catch SIGSEGV, when I use attach mode, because libbinder not produce SIGSEGV in attach mode for me, and I can catch errors with memory access