### PR TITLE
Added recordAdditionalConfig to profiler-config

### DIFF
--- a/src/profiler.ts
+++ b/src/profiler.ts
@@ -59,6 +59,7 @@ class ProfilerDebugAdapter extends debugadapter.LoggingDebugSession {
         const config = this.session.configuration;
         const frequency = config.frequency ?? 4000;
         const event = config.event ?? "cpu-clock";
+		const recordAdditionalArgs = config.recordAdditionalArgs ?? "";
 
         const command = [simpleperfDevicePath, "record", "-o", this.simpleperfOutputDevicePath, "-f", frequency.toString(), "-e", event];
 
@@ -80,6 +81,10 @@ class ProfilerDebugAdapter extends debugadapter.LoggingDebugSession {
         if (config.pid) {
             command.push("-p", config.pid);
         }
+
+		if (recordAdditionalArgs) {
+			command.push(...recordAdditionalArgs.split(" "));
+		}
 
         return command.join(" ");
     }


### PR DESCRIPTION
While profiling word-android app >80% frames were lost or truncated during profiling. And there is need to pass additional argument to profiler e.g. --user-buffer-size.
Instead of hard-coding this additional argument, I have added another config option to provide additional argument. And appended it to simplePerf record command line.